### PR TITLE
fix auth linux bug

### DIFF
--- a/Functions/Connect-CloudSuiteTenant.ps1
+++ b/Functions/Connect-CloudSuiteTenant.ps1
@@ -236,7 +236,7 @@ function global:Connect-CloudSuiteTenant
                             $Auth.Action = "Answer"
                             # Prompt for User answer using SecureString to mask typing
                             $SecureString = Read-Host $ChosenMechanism.PromptMechChosen -AsSecureString
-                            $Auth.Answer = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString))
+                            $Auth.Answer = $(ConvertFrom-SecureString -SecureString $secureString -AsPlainText)
                         }
                         
                         "StartTextOob" # Out-of-bounds Authentication (User need to take action other than through typed answer)


### PR DESCRIPTION
Title:
Fixed bug where authentication fails on a Linux (Centos 9 [RH]) host with Moba Xterm

Intro:
#[System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString))

Issue was marshal point interop was causing it to escape/remove special characters and terminate the character stream
Fixed by using common string decryption funct in PoSH (ConvertFrom-SecureString) to handle decryption
Pro and Con is that its using a specific PoSH nuance and not the .NET standard

Proposed Change:
CloudSuiteEnhancementToolkit/Functions/Connect-CloudSuiteTenant.ps1
Line 239:  $Auth.Answer = $(ConvertFrom-SecureString -SecureString $secureString -AsPlainText)[System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString))
To: $Auth.Answer = $(ConvertFrom-SecureString -SecureString $secureString -AsPlainText) 
Unit Tests:
Tested auth and lib on CentOS 9 (CentOS Stream release 9 (Dev Tools installed <-- maybe not important)); Pwsh version 7.4.1
Pass/Fail: Pass
Tested auth and lib on Windows 10; PoSH version 5.1.1
Pass/Fail: Pass

Conclusion:
This will fix the bug on Linux .NET architecture i believe
Ready to merge to staging