### PR TITLE
Real Fix to Linux bug

### DIFF
--- a/Functions/Connect-CloudSuiteTenant.ps1
+++ b/Functions/Connect-CloudSuiteTenant.ps1
@@ -236,7 +236,14 @@ function global:Connect-CloudSuiteTenant
                             $Auth.Action = "Answer"
                             # Prompt for User answer using SecureString to mask typing
                             $SecureString = Read-Host $ChosenMechanism.PromptMechChosen -AsSecureString
-                            $Auth.Answer = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString))
+
+                            if([System.Environment]::OSVersion.Platform -like "Win32*"){
+                                $Auth.Answer = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString))
+                            # Made this so it could kinda work on CentOS 9; This is the way it has be for Linux to decrypt priv string
+                            }elseif([System.Environment]::OSVersion.Platform -eq "Unix"){
+                                $Auth.Answer = $(ConvertFrom-SecureString -SecureString $secureString -AsPlainText)
+                            }else{
+                                throw [System.SystemException]::new("Somehow OS was missed. Need to stop NOW.")}
                         }
                         
                         "StartTextOob" # Out-of-bounds Authentication (User need to take action other than through typed answer)


### PR DESCRIPTION
Title:
Fixed bug where authentication fails on a Linux (Centos 9 [RH]) host with Moba Xterm

Intro:
#[System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString))

Issue was marshal point interop was causing it to escape/remove special characters and terminate the character stream
Fixed by using common string decryption funct in PoSH (ConvertFrom-SecureString) to handle decryption
Pro and Con is that its using a specific PoSH nuance and not the .NET standard

Proposed Change:
CloudSuiteEnhancementToolkit/Functions/Connect-CloudSuiteTenant.ps1
Line 239:  
```powershell
$Auth.Answer = $(ConvertFrom-SecureString -SecureString $secureString -AsPlainText)[System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)) 
```
To: 
```powershell
 if([System.Environment]::OSVersion.Platform -like "Win32*"){
    $Auth.Answer = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString))
# Made this so it could kinda work on CentOS 9; This is the way it has be for Linux to decrypt priv string
}elseif([System.Environment]::OSVersion.Platform -eq "Unix"){
    $Auth.Answer = $(ConvertFrom-SecureString -SecureString $secureString -AsPlainText)
}else{
    throw [System.SystemException]::new("Somehow OS was missed. Need to stop NOW.")}
```
Unit Tests:
Tested auth and lib on CentOS 9 (CentOS Stream release 9 (Dev Tools installed <-- maybe not important)); Pwsh version 7.4.1
Pass/Fail: Pass
Tested auth and lib on Windows 10; PoSH version 5.1.1
Pass/Fail: Pass

Conclusion:
This will fix the bug on Linux .NET architecture i believe
Ready to merge to staging

DelineaPS/CloudSuiteEnhancementToolkit